### PR TITLE
feat: :sparkles: add warn callback for scripts not found

### DIFF
--- a/nrsml/utils.ts
+++ b/nrsml/utils.ts
@@ -102,6 +102,7 @@ export function deepFreeze(object: unknown) {
 
 export class FileResolver {
     includeDirectories: string[] = [];
+    warnScriptNotFound: (searchDirectories: string[], scriptPath: string) => void = () => {};
     optionsTransformer?(options: ProcessOptions): void;
 
     addIncludeDirectory(path: string) {
@@ -141,6 +142,7 @@ export class FileResolver {
 
             const path = this.findPath(searchDirectories, referencePath);
             if (path === undefined) {
+                this.warnScriptNotFound(searchDirectories, referencePath);
                 return undefined;
             }
 


### PR DESCRIPTION
by changing the `warnScriptNotFound` property of the FileResolver, one can do something like log when the `FileResolver` encounter a script not found issue. previously, the resolver will just simply fail, which is kind of a bad design choice tbh. now one can even call `exit(1)` or throw some error in the warn callback to be make the process fail early instead of causing confusing behavior